### PR TITLE
（レビュー後の修正）0113_修正_ログアウトページ_ヘッダーとパンくずリスト

### DIFF
--- a/app/assets/stylesheets/logout.scss
+++ b/app/assets/stylesheets/logout.scss
@@ -1,3 +1,58 @@
+.content_info{
+  height: 50px;
+  weight: 100%;
+  background-color: white;
+  font-size: 14px;
+  line-height: 20px;
+  border-top: solid, gray;
+  border-bottom: inset;
+  padding-top: 15px;
+  padding-left: 210px;
+  margin-bottom: 30px;
+
+  &__first{
+    weight: 50px;
+    text-align: center;
+    font-weight: normal;
+    margin-right: 12px;
+    color: black;
+    float: left;
+  } 
+  &__second{
+    font-size: 12px;
+    weight: 50px;
+    text-align: center;
+    font-weight: normal;
+    color: black;
+    margin-right: 12px;
+    float: left;
+  }
+  &__third{
+    weight: 50px;
+    text-align: center;
+    font-weight: normal;
+    color: black;
+    margin-right: 12px;
+    float: left;
+  }
+  &__foreth{
+    font-size: 12px;
+    weight: 50px;
+    text-align: center;
+    font-weight: normal;
+    color: black;
+    margin-right: 12px;
+    float: left;
+  }
+  &__fifth{
+    weight: 50px;
+    text-align: center;
+    font-weight: bold;
+    color: black;
+    float: left;
+  }
+}   
+
 .container__logout{
   padding: 64px;
   background-color: white;

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,3 +1,17 @@
+= render partial: "layouts/header"
+
+.content_info
+  .content_info__first
+    ="メルカリ"
+  .content_info__second
+    = " 〉"
+  .content_info__third
+    ="マイページ"
+  .content_info__foreth
+    = " 〉"
+  .content_info__fifth
+    = "ログアウト"    
+
 .container
   .container__side
     = render "shared/side_bar"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     get 'login', to: 'devise/sessions#new', as: :new_user_session
     post 'login', to: 'devise/sessions#create', as: :user_session   
     delete 'destroy', to: 'devise/sessions#destroy',as: :current_user_destroy
+    
   end
 
   


### PR DESCRIPTION
（スプリントレビュー後の修正）
1月13日のスプリントレビューにて、ログアウトページにヘッダーとパンくずリストが実装されていなかったため、修正した。
