### PR TITLE
0115_修正_ユーザー登録情報_都道府県

### DIFF
--- a/app/assets/stylesheets/certification.scss
+++ b/app/assets/stylesheets/certification.scss
@@ -157,7 +157,7 @@
       }            
       &__prefectures {
         margin-bottom: 40px;
-        &__box {
+        &__select {
           box-sizing: border-box;
           background-color: white;
           color: #808080;
@@ -168,9 +168,12 @@
           line-height: 45px;
           padding-left: 7px;
           margin-left: -4px;
-          margin-top: -1px;
-        }
-      }      
+          margin-top: 1px;
+          position:left;
+          }  
+        }  
+      
+    
       &__city {
         margin-bottom: 40px;
         &__box {

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -5,15 +5,12 @@ class Address < ApplicationRecord
 
   belongs_to :user, optional: true
 
-
-
+  
   PHONE_NUMBER      = /\A\d{10}\z|\A\d{11}\z/
   POST_NUMBER       = /\A\d{3}[-]\d{4}\z|^\d{3}[-]\d{2}\z|^\d{3}\z|^\d{5}\z|^\d{7}\z/
   validates :postal_code,             presence: true, format: {maximum: 100},format: { with: POST_NUMBER }
   validates :prefectures,             presence: true, length: {maximum: 100}
   validates :city,                    presence: true, length: {maximum: 50}
   validates :house_number,            presence: true, length: {maximum: 100}
-  # validates :building,                length: {maximum: 50}
-  # validates :phone_number,            format: { with: PHONE_NUMBER }
   
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,20 +1,20 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-      {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
-      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
-      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
-      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
-      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
-      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
-      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
-      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
-      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
-      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
-      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
-      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
-      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
-      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
-      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
-      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}, {id: 48, name: '未定'}
+      {name: '北海道', name: '北海道'}, {name: '青森県', name: '青森県'}, {name: '岩手県', name: '岩手県'},
+      {name: '宮城県', name: '宮城県'}, {name: '秋田県', name: '秋田県'}, {name: '山形県', name: '山形県'},
+      {name: '福島県', name: '福島県'}, {name: '茨城県', name: '茨城県'}, {name: '栃木県', name: '栃木県'},
+      {name: '群馬県', name: '群馬県'}, {name: '埼玉県', name: '埼玉県'}, {name: '千葉県', name: '千葉県'},
+      {name: '東京都', name: '東京都'}, {name: '神奈川県', name: '神奈川県'}, {name: '新潟県', name: '新潟県'},
+      {name: '富山県', name: '富山県'}, {name: '石川県', name: '石川県'}, {name: '福井県', name: '福井県'},
+      {name: '山梨県', name: '山梨県'}, {name: '長野県', name: '長野県'}, {name: '岐阜県', name: '岐阜県'},
+      {name: '静岡県', name: '静岡県'}, {name: '愛知県', name: '愛知県'}, {name: '三重県', name: '三重県'},
+      {name: '滋賀県', name: '滋賀県'}, {name: '京都府', name: '京都府'}, {name: '大阪府', name: '大阪府'},
+      {name: '兵庫県', name: '兵庫県'}, {name: '奈良県', name: '奈良県'}, {name: '和歌山県', name: '和歌山県'},
+      {name: '鳥取県', name: '鳥取県'}, {name: '島根県', name: '島根県'}, {name: '岡山県', name: '岡山県'},
+      {name: '広島県', name: '広島県'}, {name: '山口県', name: '山口県'}, {name: '徳島県', name: '徳島県'},
+      {name: '香川県', name: '香川県'}, {name: '愛媛県', name: '愛媛県'}, {name: '高知県', name: '高知県'},
+      {name: '福岡県', name: '福岡県'}, {name: '佐賀県', name: '佐賀県'}, {name: '長崎県', name: '長崎県'},
+      {name: '熊本県', name: '熊本県'}, {name: '大分県', name: '大分県'}, {name: '宮崎県', name: '宮崎県'},
+      {name: '鹿児島県', name: '鹿児島県'}, {name: '沖縄県', name: '沖縄県'}, {name: '未定', name: '未定'}
   ]
 end

--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -53,7 +53,7 @@
             = f.label '都道府県', class: 'main__form__group__label', for: "address_prefectures"
             %span.main__form__group__require 必須
             .main__form__group__select
-              = f.collection_select :prefectures, Prefecture.all, :id, :name, {prompt: "---"}, { required: 'required' }
+              = f.collection_select :prefectures, Prefecture.all, :name, :name,{prompt: "---"}, { required: 'required' }
           .main__form__group
             = f.label '市区町村', class: 'main__form__group__label', for: "address_city"
             %span.main__form__group__require 必須

--- a/app/views/users/certification.html.haml
+++ b/app/views/users/certification.html.haml
@@ -53,8 +53,7 @@
         %label.container__user_registration__lower__label 都道府県
         %span.container__user_registration__lower__optional 任意
         .container__user_registration__lower__prefectures__select
-          .container__user_registration__lower__prefectures__box
-            = collection_select :address,:prefecture_id,Prefecture.all,:id,:name,{prompt: "---"},{class: "container__user_registration__lower__prefectures__box"}
+          = collection_select :address,:prefecture_id,Prefecture.all,:name, :name,{prompt: "#{current_user.address.prefectures}"},{class: "container__user_registration__lower__prefectures__select"}
       .container__user_registration__lower__city   
         %label.container__user_registration__lower__label 市区町村
         %span.container__user_registration__lower__optional 任意


### PR DESCRIPTION
（レビュー対象外）
マイページの本人情報登録のデフォルト値を新規登録時の登録内容で表示させる
変更するに伴い、gem hashしたprefecture.rbを修正。
（修正内容）
カラムにidにて登録していた都道府県名をnameにて登録するよう変更