### PR TITLE
0115_修正_user,itemモデルのアソシエーション削除

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,6 @@ class Item < ApplicationRecord
   belongs_to :seller, class_name: 'User'
   has_many :item_images, dependent: :destroy
   belongs_to :category
-  belongs_to :user
 
   def check_category
     unless category.present? && category.has_grand_parent?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,7 @@ class User < ApplicationRecord
   # belongs_to_active_hash :birthyear
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
-  has_many :items       
+       
   has_many :sns_credentials       
   has_one :address
   has_one :card      


### PR DESCRIPTION
(レビュー対象外）
userとitemモデルの連携はすでに実装済のため下記コードを削除
user.rb→has_many  :items
item.rb→belongs_to :user